### PR TITLE
fix: change isValid() condition

### DIFF
--- a/src/airplay.js
+++ b/src/airplay.js
@@ -3,7 +3,7 @@ import {BasePlugin, core} from 'kaltura-player-js';
 import {AirPlayButton} from './components/AirPlayButton';
 import {EventType} from './event-type';
 
-const {Env, FakeEvent} = core;
+const {FakeEvent} = core;
 
 const pluginName: string = 'airplay';
 
@@ -11,7 +11,7 @@ class AirPlay extends BasePlugin {
   static defaultConfig: Object = {};
 
   static isValid() {
-    return Env.isSafari;
+    return !!window.WebKitPlaybackTargetAvailabilityEvent;
   }
 
   _isActive: boolean = false;


### PR DESCRIPTION
### Description of the Changes

Change isValid() API condition to be depends on the existents of `WebKitPlaybackTargetAvailabilityEvent` in the browser. 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
