### PR TITLE
fix(SUP-52915): AirPlay button not visible on initial load in desktop Safari

### DIFF
--- a/src/airplay.js
+++ b/src/airplay.js
@@ -16,6 +16,7 @@ class AirPlay extends BasePlugin {
 
   _isActive: boolean = false;
   _wasPaused: boolean = false;
+  _isAvailable: boolean = false;
 
   constructor(name: string, player: KalturaPlayer, config: Object) {
     super(name, player, config);
@@ -31,7 +32,8 @@ class AirPlay extends BasePlugin {
         get: AirPlayButton,
         beforeComponent: 'PictureInPicture',
         props: {
-          startAirplay: this.startAirplay
+          startAirplay: this.startAirplay,
+          getAirPlayAvailability: () => this._isAvailable
         }
       }
     ];
@@ -45,21 +47,31 @@ class AirPlay extends BasePlugin {
 
   _attachListeners() {
     if (window.WebKitPlaybackTargetAvailabilityEvent) {
-      this.eventManager.listenOnce(this.player, this.player.Event.SOURCE_SELECTED, () => {
-        this.logger.debug('Attach webkit listeners');
-        this.eventManager.listen(this.player.getVideoElement(), 'webkitplaybacktargetavailabilitychanged', this._availabilityChangedHandler);
-        this.eventManager.listen(this.player.getVideoElement(), 'webkitcurrentplaybacktargetiswirelesschanged', this._activityChangedHandler);
+      this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, () => {
+        this._registerWebkitListeners();
       });
     }
+  }
+
+  _registerWebkitListeners() {
+    const videoElement = this.player.getVideoElement();
+    if (!videoElement) return;
+    this.logger.debug('Attach webkit listeners');
+    this.eventManager.unlisten(videoElement, 'webkitplaybacktargetavailabilitychanged');
+    this.eventManager.unlisten(videoElement, 'webkitcurrentplaybacktargetiswirelesschanged');
+    this.eventManager.listen(videoElement, 'webkitplaybacktargetavailabilitychanged', this._availabilityChangedHandler);
+    this.eventManager.listen(videoElement, 'webkitcurrentplaybacktargetiswirelesschanged', this._activityChangedHandler);
   }
 
   _availabilityChangedHandler = (event: Event & {availability: string}) => {
     this.logger.debug(`Availability changed to ${event.availability}`);
     switch (event.availability) {
       case 'available':
+        this._isAvailable = true;
         this.player.dispatchEvent(new FakeEvent(EventType.AIRPLAY_AVAILABILITY_CHANGED, {isAvailable: true}));
         break;
       case 'not-available':
+        this._isAvailable = false;
         this.player.dispatchEvent(new FakeEvent(EventType.AIRPLAY_AVAILABILITY_CHANGED, {isAvailable: false}));
         break;
     }

--- a/src/components/AirPlayButton.js
+++ b/src/components/AirPlayButton.js
@@ -38,6 +38,9 @@ class AirPlayButton extends Component {
     this.props.eventManager.listen(this.props.player, EventType.AIRPLAY_AVAILABILITY_CHANGED, this.airPlayAvailabilityChangedHandler);
     this.props.eventManager.listen(this.props.player, EventType.AIRPLAY_STARTED, this.airPlayStartedHandler);
     this.props.eventManager.listen(this.props.player, EventType.AIRPLAY_ENDED, this.airPlayEndedHandler);
+    if (typeof this.props.getAirPlayAvailability === 'function' && this.props.getAirPlayAvailability()) {
+      this.setState({isAvailable: true});
+    }
   }
 
   airPlayAvailabilityChangedHandler = (event: FakeEvent) => {


### PR DESCRIPTION
**Issue:** On initial page load in Safari on desktop, the AirPlay button was not visible in the player controls. Toggling Picture-in-Picture would cause it to appear, indicating the button was hidden due to a missed availability event.

**Root cause:** Two related timing issues:

1. `listenOnce(SOURCE_SELECTED)` meant that if the engine was recreated (e.g., due to a network error triggering a source retry or engine type change), the webkit event listeners were never registered on the new video element. Without a listener on `webkitplaybacktargetavailabilitychanged`, the `AIRPLAY_AVAILABILITY_CHANGED` event was never dispatched, so `AirPlayButton` stayed hidden.

2. The `AirPlayButton` Preact component is added via `addComponent()`, which triggers an async `setState` in the UI layer — the component may not be mounted yet when `SOURCE_SELECTED` fires and Safari dispatches `webkitplaybacktargetavailabilitychanged` synchronously during `addEventListener`. In that case the `AIRPLAY_AVAILABILITY_CHANGED` event is dispatched before `componentWillMount()` registers the listener, and the button misses it entirely. Toggling PiP caused Safari to re-fire the event, which is why that workaround worked.

**Fix:**

- Changed `listenOnce(SOURCE_SELECTED)` to `listen(SOURCE_SELECTED)` so webkit listeners are re-registered on every source selection (including after engine recreation). `_registerWebkitListeners()` unlistens before re-listening to prevent duplicates.
- Added `_isAvailable` state tracking in the plugin, updated by `_availabilityChangedHandler`.
- Passed a `getAirPlayAvailability` getter as a prop to `AirPlayButton`. In `componentWillMount()`, the component now reads the current availability immediately after subscribing to the event — so even if the `AIRPLAY_AVAILABILITY_CHANGED` event fired before the component mounted, it picks up the correct state on mount.

[SUP-52915](https://kaltura.atlassian.net/browse/SUP-52915)

[SUP-52915]: https://kaltura.atlassian.net/browse/SUP-52915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ