### PR TITLE
fix(SUP-52915): AirPlay button not visible on initial load in Player V7 on desktop Safari — requires PiP toggle to appear

### DIFF
--- a/src/airplay.js
+++ b/src/airplay.js
@@ -45,7 +45,7 @@ class AirPlay extends BasePlugin {
 
   _attachListeners() {
     if (window.WebKitPlaybackTargetAvailabilityEvent) {
-      this.eventManager.listenOnce(this.player, this.player.Event.SOURCE_SELECTED, () => {
+      this.eventManager.listenOnce(this.player, this.player.Event.LOAD_START, () => {
         this.logger.debug('Attach webkit listeners');
         this.eventManager.listen(this.player.getVideoElement(), 'webkitplaybacktargetavailabilitychanged', this._availabilityChangedHandler);
         this.eventManager.listen(this.player.getVideoElement(), 'webkitcurrentplaybacktargetiswirelesschanged', this._activityChangedHandler);


### PR DESCRIPTION
issue:
sometimes the airplay button does not appears, but after click the pip button it appears

root cause:
the event "webkitplaybacktargetavailabilitychanged" is throw by the browser only after there is video element and after there is a src in the element.it do the check once the listener is created.
source_selected event might be too soon sometimes so the when the browser did it check, it was too soon so the event didnt throw at all. once exist to pip it go out of kaltura player so there is a new check.

solution:
change the event to more later event but before the first play so when click play or start automatically the airplay will already be available

solve [SUP-52915 ](https://kaltura.atlassian.net/browse/SUP-52915)